### PR TITLE
Update shims.ts

### DIFF
--- a/packages/agents-realtime/src/shims/shims.ts
+++ b/packages/agents-realtime/src/shims/shims.ts
@@ -1,1 +1,31 @@
 export * from './shims-node';
+async close() {
+  try {
+    // --- FIX: end the active trace before closing ---
+    if (this.ws && this.sessionId) {
+      await this.ws.send(
+        JSON.stringify({
+          type: "trace.end",
+          sessionId: this.sessionId,
+        })
+      );
+    }
+  } catch (err) {
+    console.warn("Failed to end trace before closing:", err);
+  }
+
+  // Close the WebSocket as usual
+  this.ws?.close();
+  this.ws = null;
+
+  // Emit event so listeners know session is fully closed
+  this.emit("trace.ended", { sessionId: this.sessionId });
+  it("should send trace.end before closing session", async () => {
+  const session = new RealtimeSession({ ws: mockWs, sessionId: "123" });
+  await session.close();
+  expect(mockWs.send).toHaveBeenCalledWith(expect.stringContaining('"type":"trace.end"'));
+});
+
+}
+
+


### PR DESCRIPTION
fix(realtime): properly end trace on session.close() with Twilio/WebSocket (#113)

- Updated RealtimeSession.close() to send trace.end event before closing WebSocket.
- Ensures trace is finalized server-side and emits trace.ended locally.