### PR TITLE
Update package.json

### DIFF
--- a/packages/agents-core/package.json
+++ b/packages/agents-core/package.json
@@ -12,6 +12,21 @@
     "build": "tsc",
     "build-check": "tsc --noEmit -p ./tsconfig.test.json"
   },
+  "scripts": {
+  "build:esm": "tsc --project tsconfig.json",
+  "build:cjs": "tsc --project tsconfig.cjs.json",
+  "build": "npm run build:esm && npm run build:cjs"
+},
+"main": "./dist-cjs/index.js",     // <-- CJS build output
+"module": "./dist/index.js",
+"types": "./dist/index.d.ts",
+"exports": {
+  ".": {
+    "import": "./dist/index.js",
+    "require": "./dist-cjs/index.js"
+  }
+}
+
   "exports": {
     ".": {
       "require": {


### PR DESCRIPTION
fix(agents-core): add proper CommonJS build for Node/AWS Lambda compatibility

- Added `tsconfig.cjs.json` to produce a real CommonJS build in `dist-cjs/`
- Updated package.json `exports` to point `require` to the CJS build
- Ensures `@openai/agents-core` works with Node 22 and AWS Lambda (fixes #245)