### PR TITLE
Update shims.ts

### DIFF
--- a/packages/agents-realtime/src/shims/shims.ts
+++ b/packages/agents-realtime/src/shims/shims.ts
@@ -1,1 +1,19 @@
 export * from './shims-node';
+let transport;
+if (client?.constructor?.name === "AzureOpenAI") {
+  // Use Azure-specific transport for Realtime
+  transport = await OpenAIRealtimeWS.azure(client);
+} else {
+  // Default OpenAI realtime transport
+  transport = await OpenAIRealtimeWS.openai(client);
+}
+if (client?.constructor?.name === "AzureOpenAI" && !OpenAIRealtimeWS.azure) {
+  throw new Error(
+    "Azure OpenAI Realtime is not supported in this SDK. Please use OpenAIRealtimeWS.azure()."
+  );
+}
+if (client?.constructor?.name === "AzureOpenAI" && !OpenAIRealtimeWS.azure) {
+  throw new Error(
+    "Azure OpenAI Realtime is not supported in this SDK. Please use OpenAIRealtimeWS.azure()."
+  );
+}


### PR DESCRIPTION
fix(mcp): add Azure OpenAI transport detection for RealtimeAgent

- Detect AzureOpenAI clients in shims.ts
- Route to OpenAIRealtimeWS.azure(...) instead of default openai()
- Add explicit error for unsupported Azure realtime configurations
- Fixes #214