### PR TITLE
Update run.ts

### DIFF
--- a/packages/agents-core/src/run.ts
+++ b/packages/agents-core/src/run.ts
@@ -71,6 +71,22 @@ if (modelSettings.toolChoice === 'none') {
     parallel_tool_calls: false, // also disable parallel tool calls
   };
 }
+const hookOverride = await agent.hooks?.on_before_model?.(runContext, agent);
+
+if (hookOverride?.modelSettings !== undefined) {
+  modelSettings = modelSettings.resolve(hookOverride.modelSettings);
+}
+
+// --- Fix for Issue #116: Ensure toolChoice = 'none' is honored ---
+if (hookOverride?.modelSettings?.toolChoice === 'none') {
+  modelSettings = {
+    ...modelSettings,
+    toolChoice: 'none',
+    parallel_tool_calls: false, // prevent accidental tool calls
+  };
+}
+// ----------------------------------------------------------------
+
 // -----------------------------------------------
 
 


### PR DESCRIPTION
fix(agents-core): honor toolChoice='none' set in lifecycle hooks

- Ensures that toolChoice='none' from on_before_model hook overrides is enforced
- Disables parallel tool calls when toolChoice is 'none'
- Fixes #116